### PR TITLE
Fix compile warning by removing unused DatePipe

### DIFF
--- a/src/app/features/projects/project-list/project-list.ts
+++ b/src/app/features/projects/project-list/project-list.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { CommonModule, DatePipe } from '@angular/common';
+import { CommonModule } from '@angular/common';
 import { ProjectModel } from '../models/project.model';
 import { ProjectViewerComponent } from '../project-viewer/project-viewer.component';
 import { ProjectService } from '../project.service';
@@ -10,7 +10,7 @@ import { StackTrailService } from '../../../stack-trail.service';
   selector: 'app-project-list',
   templateUrl: './project-list.html',
   standalone: true,
-  imports: [ProjectViewerComponent, ProjectCardComponent, DatePipe, CommonModule],
+  imports: [ProjectViewerComponent, ProjectCardComponent, CommonModule],
 })
 export class ProjectList {
   loading = false;


### PR DESCRIPTION
## Summary
- remove unused `DatePipe` from `ProjectList` imports

## Testing
- `npm test` *(fails: ng not found)*
- `npm run build` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_685cb3a658208333b4c8ef18219e3dc5