### PR TITLE
Implement contextual agent framework

### DIFF
--- a/src/app/components/game-chat/context-tracking.service.ts
+++ b/src/app/components/game-chat/context-tracking.service.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+import { ContextInfo } from './game-chat.models';
+
+@Injectable({ providedIn: 'root' })
+export class ContextTrackingService {
+  private stack: ContextInfo[] = [];
+  private contextSubject = new BehaviorSubject<ContextInfo | null>(null);
+  readonly context$ = this.contextSubject.asObservable();
+
+  push(context: ContextInfo): void {
+    this.stack.push(context);
+    this.contextSubject.next(context);
+  }
+
+  getCurrent(): ContextInfo | null {
+    return this.stack.length ? this.stack[this.stack.length - 1] : null;
+  }
+}

--- a/src/app/components/game-chat/game-chat.html
+++ b/src/app/components/game-chat/game-chat.html
@@ -20,6 +20,12 @@
               <span class="text-xs text-gris-medio">{{ msg.timestamp | date:'HH:mm' }}</span>
             </div>
             <p class="text-sm text-gris-claro leading-relaxed">{{ msg.text }}</p>
+            <div *ngIf="msg.suggestions?.length" class="mt-2 flex gap-1 flex-wrap">
+              <button *ngFor="let s of msg.suggestions" (click)="text = s" class="px-2 py-0.5 text-xs rounded bg-holo-blue text-white hover:bg-dorado hover:text-antracita">{{ s }}</button>
+            </div>
+            <div class="text-xs text-gris-medio mt-1" *ngIf="msg.context">
+              Hablando sobre: {{ msg.context.section }}
+            </div>
             <div class="absolute inset-0 bg-gradient-to-r from-transparent via-holo-blue/5 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300 rounded-lg"></div>
           </div>
         </div>

--- a/src/app/components/game-chat/game-chat.models.ts
+++ b/src/app/components/game-chat/game-chat.models.ts
@@ -1,0 +1,41 @@
+export enum AgentType {
+  PROJECT_GUIDE = 'PROJECT_GUIDE',
+  TECH_EXPERT = 'TECH_EXPERT',
+  PORTFOLIO_HOST = 'PORTFOLIO_HOST',
+  CONTACT_ASSISTANT = 'CONTACT_ASSISTANT'
+}
+
+export interface AgentInfo {
+  type: AgentType;
+  name: string;
+  icon: string;
+  color: string;
+  personality: 'formal' | 'casual' | 'technical' | 'enthusiastic';
+  expertise: string[];
+  greetingTemplates: string[];
+}
+
+export interface ContextInfo {
+  section: string;
+  projectId?: string;
+  metadata: any;
+  timestamp: Date;
+}
+
+export interface ChatMessage {
+  id: string;
+  text: string;
+  timestamp: Date;
+  agent: AgentInfo;
+  context: ContextInfo;
+  suggestions?: string[];
+  isContextual: boolean;
+  from: 'user' | 'bot';
+}
+
+export interface ProjectContext {
+  projectId: string;
+  title: string;
+  technologies: string[];
+  viewedAt: Date;
+}

--- a/src/app/components/game-chat/game-chat.service.ts
+++ b/src/app/components/game-chat/game-chat.service.ts
@@ -2,43 +2,86 @@ import { Injectable } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
 import { NavigationEnd, Router } from '@angular/router';
 import { AiService } from '../../features/ai/ai.service';
+import { ChatContextService } from '../../features/ai/chat-context.service';
+import {
+  AgentInfo,
+  AgentType,
+  ChatMessage,
+  ContextInfo,
+} from './game-chat.models';
+import { ContextTrackingService } from './context-tracking.service';
 
-export interface GameChatAgent {
-  id: string;
-  name: string;
-  color: string;
-  icon: string;
-}
-
-export interface GameChatMessage {
-  id: string;
-  agent: GameChatAgent;
-  text: string;
-  from: 'user' | 'bot';
-  timestamp: Date;
-}
 
 @Injectable({ providedIn: 'root' })
 export class GameChatService {
   private openSubject = new BehaviorSubject<boolean>(false);
   open$ = this.openSubject.asObservable();
 
-  private messagesSubject = new BehaviorSubject<GameChatMessage[]>([]);
+  private messagesSubject = new BehaviorSubject<ChatMessage[]>([]);
   messages$ = this.messagesSubject.asObservable();
 
-  agents: GameChatAgent[] = [
-    { id: 'guide', name: 'Guide', color: 'dorado', icon: '🤖' }
+  agents: AgentInfo[] = [
+    {
+      type: AgentType.PROJECT_GUIDE,
+      name: 'ProjectGuide',
+      icon: '🎯',
+      color: 'dorado',
+      personality: 'technical',
+      expertise: ['projects'],
+      greetingTemplates: ['¡Hola! Soy ProjectGuide 🎯']
+    },
+    {
+      type: AgentType.TECH_EXPERT,
+      name: 'TechBot',
+      icon: '🤖',
+      color: 'holo-blue',
+      personality: 'technical',
+      expertise: ['tech'],
+      greetingTemplates: ['Hola, soy TechBot 🤖']
+    },
+    {
+      type: AgentType.PORTFOLIO_HOST,
+      name: 'Host',
+      icon: '🧑‍💼',
+      color: 'purpura-profundo',
+      personality: 'formal',
+      expertise: ['portfolio'],
+      greetingTemplates: ['Bienvenido al portfolio']
+    },
+    {
+      type: AgentType.CONTACT_ASSISTANT,
+      name: 'ContactBot',
+      icon: '✉️',
+      color: 'cyber-green',
+      personality: 'enthusiastic',
+      expertise: ['contact'],
+      greetingTemplates: ['¿Quieres enviar un mensaje?']
+    }
   ];
 
-  constructor(private ai: AiService) {
-    const welcome: GameChatMessage = {
+  private activeAgent = this.agents[0];
+
+  constructor(
+    private ai: AiService,
+    private backend: ChatContextService,
+    private context: ContextTrackingService
+  ) {
+    const welcome: ChatMessage = {
       id: crypto.randomUUID(),
-      agent: this.agents[0],
+      agent: this.activeAgent,
       text: '¡Bienvenido! ¿En qué puedo ayudarte hoy?',
       from: 'bot',
+      context: { section: 'home', metadata: {}, timestamp: new Date() },
+      isContextual: true,
       timestamp: new Date()
     };
     this.messagesSubject.next([welcome]);
+
+    this.context.context$.subscribe(c => {
+      if (c) {
+        this.switchAgentForSection(c.section);
+      }
+    });
   }
 
   trackClicks() {
@@ -46,6 +89,13 @@ export class GameChatService {
       const el = evt.target as HTMLElement | null;
       if (!el) return;
       const desc = el.getAttribute('data-testid') || el.getAttribute('aria-label') || el.tagName.toLowerCase();
+      const ctx: ContextInfo = {
+        section: 'click',
+        metadata: desc,
+        timestamp: new Date(),
+      };
+      this.context.push(ctx);
+      this.backend.sendContext({ section: 'click', action: desc, userContext: {} }).subscribe();
       this.sendTrace(`click:${desc}`);
     });
   }
@@ -53,6 +103,13 @@ export class GameChatService {
   trackRouteChanges(router: Router) {
     router.events.subscribe((event: any) => {
       if (event instanceof NavigationEnd) {
+        const ctx: ContextInfo = {
+          section: event.urlAfterRedirects.replace('/', ''),
+          metadata: {},
+          timestamp: new Date(),
+        };
+        this.context.push(ctx);
+        this.backend.sendContext({ section: ctx.section, action: 'navigate', userContext: {} }).subscribe();
         this.sendTrace(`route:${event.urlAfterRedirects}`);
       }
     });
@@ -66,38 +123,58 @@ export class GameChatService {
     this.openSubject.next(!this.openSubject.value);
   }
 
-  sendMessage(agent: GameChatAgent, text: string) {
-    const userMsg: GameChatMessage = {
+  sendMessage(agent: AgentInfo, text: string) {
+    const current = this.context.getCurrent() || { section: 'home', metadata: {}, timestamp: new Date() };
+    const userMsg: ChatMessage = {
       id: crypto.randomUUID(),
       agent,
       text,
       from: 'user',
+      context: current,
+      isContextual: false,
       timestamp: new Date()
     };
     this.messagesSubject.next([...this.messagesSubject.value, userMsg]);
 
-    this.ai.sendChatMessage(text).subscribe({
-      next: reply => {
-        const botMsg: GameChatMessage = {
+    this.backend.sendMessage(text, current, agent.type).subscribe({
+      next: (reply: any) => {
+        const botMsg: ChatMessage = {
           id: crypto.randomUUID(),
           agent,
-          text: reply,
+          text: reply.message || reply,
           from: 'bot',
+          context: current,
+          isContextual: true,
           timestamp: new Date()
         };
         this.messagesSubject.next([...this.messagesSubject.value, botMsg]);
       },
       error: () => {
-        const botMsg: GameChatMessage = {
+        const botMsg: ChatMessage = {
           id: crypto.randomUUID(),
           agent,
           text: 'Error contacting AI',
           from: 'bot',
+          context: current,
+          isContextual: true,
           timestamp: new Date()
         };
         this.messagesSubject.next([...this.messagesSubject.value, botMsg]);
       }
     });
+  }
+
+  private switchAgentForSection(section: string): void {
+    switch (section) {
+      case 'projects':
+        this.activeAgent = this.agents.find(a => a.type === AgentType.PROJECT_GUIDE) || this.activeAgent;
+        break;
+      case 'contact':
+        this.activeAgent = this.agents.find(a => a.type === AgentType.CONTACT_ASSISTANT) || this.activeAgent;
+        break;
+      default:
+        this.activeAgent = this.agents.find(a => a.type === AgentType.PORTFOLIO_HOST) || this.activeAgent;
+    }
   }
 
   closeMessage(id: string) {

--- a/src/app/components/game-chat/game-chat.spec.ts
+++ b/src/app/components/game-chat/game-chat.spec.ts
@@ -1,22 +1,31 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { BehaviorSubject } from 'rxjs';
 import { GameChatComponent } from './game-chat';
-import { GameChatService, GameChatAgent, GameChatMessage } from './game-chat.service';
+import { GameChatService } from './game-chat.service';
+import { AgentInfo, AgentType, ChatMessage } from './game-chat.models';
 
 class MockGameChatService {
   private openSubject = new BehaviorSubject<boolean>(false);
   open$ = this.openSubject.asObservable();
 
-  private messagesSubject: BehaviorSubject<GameChatMessage[]>;
+  private messagesSubject: BehaviorSubject<ChatMessage[]>;
   messages$;
 
-  agents: GameChatAgent[] = [
-    { id: 'guide', name: 'Guide', color: 'dorado', icon: '🤖' }
+  agents: AgentInfo[] = [
+    {
+      type: AgentType.PROJECT_GUIDE,
+      name: 'Guide',
+      color: 'dorado',
+      icon: '🤖',
+      personality: 'technical',
+      expertise: [],
+      greetingTemplates: []
+    }
   ];
 
   constructor() {
-    this.messagesSubject = new BehaviorSubject<GameChatMessage[]>([
-      { id: '1', agent: this.agents[0], text: 'Welcome!', from: 'bot', timestamp: new Date() }
+    this.messagesSubject = new BehaviorSubject<ChatMessage[]>([
+      { id: '1', agent: this.agents[0], text: 'Welcome!', from: 'bot', timestamp: new Date(), context: { section: 'home', metadata: {}, timestamp: new Date() }, isContextual: true }
     ]);
     this.messages$ = this.messagesSubject.asObservable();
   }

--- a/src/app/components/game-chat/game-chat.ts
+++ b/src/app/components/game-chat/game-chat.ts
@@ -1,7 +1,8 @@
 import { Component, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { GameChatService, GameChatMessage } from './game-chat.service';
+import { GameChatService } from './game-chat.service';
+import { ChatMessage, AgentInfo } from './game-chat.models';
 
 @Component({
   selector: 'app-game-chat',
@@ -15,10 +16,10 @@ export class GameChatComponent {
   open$ = this.service.open$;
   messages$ = this.service.messages$;
   text = '';
-  agent = this.service.agents[0];
+  agent: AgentInfo = this.service.agents[0];
 
   visibleIds = signal<string[]>([]);
-  allMessages: GameChatMessage[] = [];
+  allMessages: ChatMessage[] = [];
 
   constructor() {
     this.messages$.subscribe(msgs => {
@@ -35,7 +36,7 @@ export class GameChatComponent {
     });
   }
 
-  trackById(_: number, msg: GameChatMessage) {
+  trackById(_: number, msg: ChatMessage) {
     return msg.id;
   }
 

--- a/src/app/features/ai/chat-context.service.ts
+++ b/src/app/features/ai/chat-context.service.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { environment } from '../../../environments/environment';
+import { AgentType, ContextInfo } from '../../components/game-chat/game-chat.models';
+
+interface ContextRequest {
+  section: string;
+  projectId?: string;
+  action: string;
+  userContext: any;
+}
+
+@Injectable({ providedIn: 'root' })
+export class ChatContextService {
+  private root = `${environment.apiRoot}/chat`;
+
+  constructor(private http: HttpClient) {}
+
+  sendContext(req: ContextRequest): Observable<any> {
+    return this.http.post(`${this.root}/context`, req);
+  }
+
+  getAgent(type: AgentType): Observable<any> {
+    return this.http.get(`${this.root}/agent/${type}`);
+  }
+
+  sendMessage(message: string, context: ContextInfo, agent: AgentType): Observable<any> {
+    return this.http.post(`${this.root}/message`, { message, context, agent }).pipe(map((r:any)=>r));
+  }
+}

--- a/src/app/features/projects/models/project.model.ts
+++ b/src/app/features/projects/models/project.model.ts
@@ -5,5 +5,6 @@ export interface ProjectModel {
   link: string;
   createdDate: string; 
   githubRepo: string;
-  stack: string;      
+  stack: string;
+  imageUrl?: string;
 }

--- a/src/app/features/projects/project-list/project-list.html
+++ b/src/app/features/projects/project-list/project-list.html
@@ -35,5 +35,6 @@
 <app-project-viewer
   *ngIf="selectedProject$ | async as sp"
   [project]="sp"
-  (close)="closeViewer()">
-</app-project-viewer>
+  (close)="closeViewer()"
+  (projectViewed)="onProjectViewed($event)"
+></app-project-viewer>

--- a/src/app/features/projects/project-list/project-list.ts
+++ b/src/app/features/projects/project-list/project-list.ts
@@ -8,6 +8,8 @@ import { TraceService } from '../../../core/trace.service';
 import { BehaviorSubject, Subject, Observable, of } from 'rxjs';
 import { takeUntil, tap, catchError, shareReplay } from 'rxjs/operators';
 import { AiService } from '../../ai/ai.service';
+import { GameChatService } from '../../../components/game-chat/game-chat.service';
+import { ProjectContext, AgentType } from '../../../components/game-chat/game-chat.models';
 
 @Component({
   selector: 'app-project-list',
@@ -31,7 +33,8 @@ export class ProjectList implements OnInit, OnDestroy {
     private projectService: ProjectService,
     private aiService: AiService,
     private stackTrail: StackTrailService,
-    private trace: TraceService
+    private trace: TraceService,
+    private chat: GameChatService
   ) {
     this.selectedProject$ = this.projectService.selectedProject$;
   }
@@ -70,6 +73,11 @@ export class ProjectList implements OnInit, OnDestroy {
     this.trace.trace('project selected', project);
     this.stackTrail.addStack(project.stack);
     this.projectService.selectProject(project);
+  }
+
+  onProjectViewed(ctx: ProjectContext) {
+    const agent = this.chat.agents.find(a => a.type === AgentType.TECH_EXPERT) || this.chat.agents[0];
+    this.chat.sendMessage(agent, `Estoy revisando ${ctx.title}. Usa ${ctx.technologies.join(', ')}`);
   }
 
   getAiMessage() {

--- a/src/app/features/projects/project-viewer/project-viewer.component.html
+++ b/src/app/features/projects/project-viewer/project-viewer.component.html
@@ -10,9 +10,9 @@
       <h2 class="text-2xl font-heading text-dorado" *ngIf="project?.title">{{ project?.title }}</h2>
       <img *ngIf="project?.imageUrl" [src]="project?.imageUrl" [attr.alt]="project?.title || ''" class="rounded-xl shadow-lg w-full max-h-60 object-cover" loading="lazy" />
       <p class="text-gris-claro font-body" *ngIf="project?.description">
-        {{ showFullDesc ? project?.description : (project?.description | slice:0:200) }}<span *ngIf="!showFullDesc && (project?.description?.length > 200)">...</span>
+        {{ showFullDesc ? project?.description : (project?.description | slice:0:200) }}<span *ngIf="!showFullDesc && project?.description && project.description.length > 200">...</span>
       </p>
-      <button *ngIf="project?.description?.length > 200" (click)="toggleDescription()" class="self-start text-sm text-dorado hover:underline">
+      <button *ngIf="project?.description && project.description.length > 200" (click)="toggleDescription()" class="self-start text-sm text-dorado hover:underline">
         {{ showFullDesc ? 'Read less' : 'Read more' }}
       </button>
       <div *ngIf="project?.stack as stack" class="flex flex-wrap gap-2 mt-2">

--- a/src/app/features/projects/project-viewer/project-viewer.component.html
+++ b/src/app/features/projects/project-viewer/project-viewer.component.html
@@ -7,26 +7,26 @@
 
     <!-- Project Panel -->
     <div class="p-6 flex flex-col gap-4">
-      <h2 class="text-2xl font-heading text-dorado" *ngIf="project?.title">{{ project.title }}</h2>
-      <img *ngIf="project?.imageUrl" [src]="project.imageUrl" [alt]="project.title" class="rounded-xl shadow-lg w-full max-h-60 object-cover" loading="lazy" />
+      <h2 class="text-2xl font-heading text-dorado" *ngIf="project?.title">{{ project?.title }}</h2>
+      <img *ngIf="project?.imageUrl" [src]="project?.imageUrl" [attr.alt]="project?.title || ''" class="rounded-xl shadow-lg w-full max-h-60 object-cover" loading="lazy" />
       <p class="text-gris-claro font-body" *ngIf="project?.description">
-        {{ showFullDesc ? project.description : (project.description | slice:0:200) }}<span *ngIf="!showFullDesc && (project.description?.length > 200)">...</span>
+        {{ showFullDesc ? project?.description : (project?.description | slice:0:200) }}<span *ngIf="!showFullDesc && (project?.description?.length > 200)">...</span>
       </p>
       <button *ngIf="project?.description?.length > 200" (click)="toggleDescription()" class="self-start text-sm text-dorado hover:underline">
         {{ showFullDesc ? 'Read less' : 'Read more' }}
       </button>
-      <div *ngIf="project?.stack" class="flex flex-wrap gap-2 mt-2">
-        <span *ngFor="let tech of project.stack.split(',')" class="px-3 py-1 rounded-full text-xs font-heading bg-dorado text-antracita">
+      <div *ngIf="project?.stack as stack" class="flex flex-wrap gap-2 mt-2">
+        <span *ngFor="let tech of stack.split(',')" class="px-3 py-1 rounded-full text-xs font-heading bg-dorado text-antracita">
           {{ tech.trim() }}
         </span>
       </div>
-      <span *ngIf="project?.createdDate" class="text-xs text-gris-medio">{{ project.createdDate | date }}</span>
+      <span *ngIf="project?.createdDate" class="text-xs text-gris-medio">{{ project?.createdDate | date }}</span>
       <div class="flex gap-3 mt-auto">
-        <a *ngIf="project?.githubRepo" [href]="'https://github.com/' + project.githubRepo" target="_blank" rel="noopener" aria-label="View Source" class="flex items-center gap-1 px-4 py-2 rounded bg-dorado text-antracita font-heading hover:bg-rojo-oscuro hover:text-dorado transition">
+        <a *ngIf="project?.githubRepo" [href]="'https://github.com/' + project?.githubRepo" target="_blank" rel="noopener" aria-label="View Source" class="flex items-center gap-1 px-4 py-2 rounded bg-dorado text-antracita font-heading hover:bg-rojo-oscuro hover:text-dorado transition">
           <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 0C5.371 0 0 5.372 0 12c0 5.302 3.438 9.8 8.207 11.387.6.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.757-1.333-1.757-1.089-.745.083-.73.083-.73 1.205.085 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.108-.775.419-1.305.762-1.605-2.665-.304-5.466-1.332-5.466-5.932 0-1.31.469-2.381 1.236-3.221-.124-.303-.536-1.524.118-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.984-.399 3.003-.404 1.019.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.656 1.652.244 2.873.12 3.176.77.84 1.235 1.911 1.235 3.221 0 4.61-2.804 5.625-5.476 5.921.43.371.823 1.102.823 2.222v3.293c0 .319.192.694.801.576C20.565 21.796 24 17.299 24 12c0-6.628-5.372-12-12-12z"/></svg>
           <span>View Source</span>
         </a>
-        <a *ngIf="project?.link" [href]="project.link" target="_blank" rel="noopener" aria-label="Open Demo" class="flex items-center gap-1 px-4 py-2 rounded bg-holo-blue text-white font-heading hover:bg-dorado hover:text-antracita transition">
+        <a *ngIf="project?.link" [href]="project?.link" target="_blank" rel="noopener" aria-label="Open Demo" class="flex items-center gap-1 px-4 py-2 rounded bg-holo-blue text-white font-heading hover:bg-dorado hover:text-antracita transition">
           <svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" d="M14 3h7v7m0-7L10 14m4 7H3V10m0 11L21 3"/></svg>
           <span>Live Demo</span>
         </a>

--- a/src/app/features/projects/project-viewer/project-viewer.component.html
+++ b/src/app/features/projects/project-viewer/project-viewer.component.html
@@ -10,9 +10,9 @@
       <h2 class="text-2xl font-heading text-dorado" *ngIf="project?.title">{{ project?.title }}</h2>
       <img *ngIf="project?.imageUrl" [src]="project?.imageUrl" [attr.alt]="project?.title || ''" class="rounded-xl shadow-lg w-full max-h-60 object-cover" loading="lazy" />
       <p class="text-gris-claro font-body" *ngIf="project?.description">
-        {{ showFullDesc ? project?.description : (project?.description | slice:0:200) }}<span *ngIf="!showFullDesc && project?.description && project.description.length > 200">...</span>
+        {{ showFullDesc ? project?.description : (project?.description | slice:0:200) }}<span *ngIf="!showFullDesc && project?.description?.length > 200">...</span>
       </p>
-      <button *ngIf="project?.description && project.description.length > 200" (click)="toggleDescription()" class="self-start text-sm text-dorado hover:underline">
+      <button *ngIf="project?.description?.length > 200" (click)="toggleDescription()" class="self-start text-sm text-dorado hover:underline">
         {{ showFullDesc ? 'Read less' : 'Read more' }}
       </button>
       <div *ngIf="project?.stack as stack" class="flex flex-wrap gap-2 mt-2">

--- a/src/app/features/projects/project-viewer/project-viewer.component.ts
+++ b/src/app/features/projects/project-viewer/project-viewer.component.ts
@@ -11,6 +11,7 @@ import { HttpClient } from '@angular/common/http';
 import { marked } from 'marked';
 import { CommonModule, DatePipe } from '@angular/common';
 import { ProjectModel } from '../models/project.model';
+import { ProjectContext } from '../../../components/game-chat/game-chat.models';
 
 @Component({
   selector: 'app-project-viewer',
@@ -22,6 +23,7 @@ import { ProjectModel } from '../models/project.model';
 export class ProjectViewerComponent implements OnChanges {
   @Input() project: ProjectModel | null = null;
   @Output() close = new EventEmitter<void>();
+  @Output() projectViewed = new EventEmitter<ProjectContext>();
   safeUrl: SafeResourceUrl | null = null;
   readmeHtml = '';
   loadingMd = false;
@@ -36,6 +38,13 @@ export class ProjectViewerComponent implements OnChanges {
     this.safeUrl = this.project.link
       ? this.sanitizer.bypassSecurityTrustResourceUrl(this.project.link)
       : null;
+    const ctx: ProjectContext = {
+      projectId: String(this.project.id),
+      title: this.project.title,
+      technologies: this.project.stack.split(',').map(t => t.trim()),
+      viewedAt: new Date(),
+    };
+    this.projectViewed.emit(ctx);
     this.fetchReadme();
   }
 


### PR DESCRIPTION
## Summary
- add shared models for chat agents, context info and project context
- implement ContextTrackingService and ChatContextService for backend integration
- expand GameChat service with multiple agents and context switching
- emit `projectViewed` events and handle them in project list
- show suggestions and context info in GameChat UI

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_685f2fe5b4c08333b23bbc0de4f3afc0