### PR TITLE
Add animated graphs for "Between" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 
 Portfolio API es un servicio RESTful desarrollado con **Java 21** y **Spring Boot 3.5.0** que permite gestionar un portafolio de proyectos, habilidades, experiencias laborales y contactos. Este backend está diseñado para ser consumido por interfaces frontend como aplicaciones web, móviles o herramientas de automatización, ofreciendo un conjunto de endpoints seguros, escalables y fáciles de integrar.
 
+La sección de frontend "What Happens Between Startup and Structure" cuenta con componentes animados documentados en [docs/between-components.md](docs/between-components.md).
+
 ---
 
 ## 🚀 **Tecnologías utilizadas**

--- a/docs/between-components.md
+++ b/docs/between-components.md
@@ -1,0 +1,29 @@
+# Between Section Components
+
+This document describes the animated components used in the "What Happens Between Startup and Structure" section.
+
+## `<app-symptom-bar>`
+
+Displays a set of vertical bars animated to mimic a fluctuating speed indicator.
+
+- **Inputs:** none
+- **Usage:** visualizes unstable velocity for the "El Síntoma" card.
+- **Animation:** CSS keyframe `bar-cycle` running every 2.5s.
+
+## `<app-entropy-wave>`
+
+SVG wave that morphs to represent narrative chaos.
+
+- **Inputs:** none
+- **Usage:** part of the "La Realidad" card.
+- **Animation:** SVG `<animate>` element with a 3s loop.
+
+## `<app-method-transform>`
+
+Illustrates transformation from catalyst to order using circles and a line.
+
+- **Inputs:** none
+- **Usage:** embedded in the "El Método" card.
+- **Animation:** SVG animations with a 3s cycle.
+
+Each component is standalone and imported into `app-between`. They scale with their container and include `role="img"` and `aria-label` attributes for accessibility.

--- a/src/app/components/between/between.html
+++ b/src/app/components/between/between.html
@@ -12,124 +12,31 @@
     </div>
 
     <!-- TRES BLOQUES PRINCIPALES -->
-    <div class="grid lg:grid-cols-3 gap-8 mb-16">
-      
-      <!-- BLOQUE 1: EL PROBLEMA -->
-      <div class="relative group cursor-pointer transform transition-all duration-500 hover:scale-105">
-        <div class="absolute inset-0 bg-gradient-to-br from-rojo-oscuro/20 to-transparent rounded-2xl blur-xl opacity-0 group-hover:opacity-100 transition-opacity duration-500"></div>
-        <div class="relative bg-gradient-to-br from-gray-900 to-gray-800 p-8 rounded-2xl border border-rojo-oscuro/20 hover:border-rojo-oscuro/50 transition-all duration-500">
-          
-          <!-- Icono animado -->
-          <div class="w-16 h-16 bg-rojo-oscuro/20 rounded-full flex items-center justify-center mb-6 mx-auto group-hover:animate-pulse">
-            <svg class="w-8 h-8 text-rojo-oscuro" fill="currentColor" viewBox="0 0 24 24">
-              <path d="M12 2L2 7v10c0 5.55 3.84 9.74 9 11 5.16-1.26 9-5.45 9-11V7l-10-5z"/>
-              <path d="M12 8v4l3 3"/>
-            </svg>
-          </div>
-          
-          <h3 class="text-2xl font-heading text-rojo-oscuro mb-4 text-center">EL SÍNTOMA</h3>
-          
-          <div class="space-y-3 text-gris-claro">
-            <div class="flex items-start gap-3">
-              <div class="w-2 h-2 bg-rojo-oscuro rounded-full mt-2 flex-shrink-0"></div>
-              <p class="text-sm">{{ translations().LINES[0] }}</p>
-            </div>
-            <div class="flex items-start gap-3">
-              <div class="w-2 h-2 bg-rojo-oscuro rounded-full mt-2 flex-shrink-0"></div>
-              <p class="text-sm opacity-90">{{ translations().LINES[1] }}</p>
-            </div>
-          </div>
-          
-          <!-- Métrica visual -->
-          <div class="mt-6 p-4 bg-black/30 rounded-lg border border-rojo-oscuro/20">
-            <div class="flex justify-between items-center mb-2">
-              <span class="text-xs text-rojo-oscuro font-semibold">VELOCIDAD</span>
-              <span class="text-xs text-rojo-oscuro">↓ 60%</span>
-            </div>
-            <div class="w-full bg-gray-700 rounded-full h-2">
-              <div class="bg-gradient-to-r from-rojo-oscuro to-red-400 h-2 rounded-full" style="width: 40%"></div>
-            </div>
-          </div>
+    <div class="grid md:grid-cols-3 gap-8 mb-16 auto-rows-fr">
+      <div class="bg-gray-900 border border-rojo-oscuro/30 rounded-2xl flex flex-col items-center p-6 text-center h-full">
+        <h3 class="text-2xl font-heading text-rojo-oscuro mb-4">EL SÍNTOMA</h3>
+        <div class="w-full h-32 mb-4">
+          <app-symptom-bar></app-symptom-bar>
         </div>
+        <p class="text-sm mb-1">{{ translations().LINES[0] }}</p>
+        <p class="text-sm opacity-90">{{ translations().LINES[1] }}</p>
       </div>
 
-      <!-- BLOQUE 2: EL DIAGNÓSTICO -->
-      <div class="relative group cursor-pointer transform transition-all duration-500 hover:scale-105">
-        <div class="absolute inset-0 bg-gradient-to-br from-dorado/20 to-transparent rounded-2xl blur-xl opacity-0 group-hover:opacity-100 transition-opacity duration-500"></div>
-        <div class="relative bg-gradient-to-br from-gray-900 to-gray-800 p-8 rounded-2xl border border-dorado/20 hover:border-dorado/50 transition-all duration-500">
-          
-          <!-- Icono animado -->
-          <div class="w-16 h-16 bg-dorado/20 rounded-full flex items-center justify-center mb-6 mx-auto group-hover:animate-spin">
-            <svg class="w-8 h-8 text-dorado" fill="currentColor" viewBox="0 0 24 24">
-              <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"/>
-            </svg>
-          </div>
-          
-          <h3 class="text-2xl font-heading text-dorado mb-4 text-center">LA REALIDAD</h3>
-          
-          <div class="space-y-3 text-gris-claro">
-            <div class="flex items-start gap-3">
-              <div class="w-2 h-2 bg-dorado rounded-full mt-2 flex-shrink-0"></div>
-              <p class="text-sm font-semibold">{{ translations().LINES[2] }}</p>
-            </div>
-            <div class="flex items-start gap-3">
-              <div class="w-2 h-2 bg-dorado rounded-full mt-2 flex-shrink-0"></div>
-              <p class="text-sm opacity-90">{{ translations().LINES[3] }}</p>
-            </div>
-          </div>
-          
-          <!-- Diagnóstico visual -->
-          <div class="mt-6 p-4 bg-black/30 rounded-lg border border-dorado/20">
-            <div class="text-center">
-              <div class="text-2xl font-bold text-dorado mb-1">ENTROPÍA</div>
-              <div class="text-xs text-gris-claro">NARRATIVA</div>
-              <div class="mt-2 flex justify-center">
-                <app-entropy></app-entropy>
-              </div>
-            </div>
-          </div>
+      <div class="bg-gray-900 border border-dorado/30 rounded-2xl flex flex-col items-center p-6 text-center h-full">
+        <h3 class="text-2xl font-heading text-dorado mb-4">LA REALIDAD</h3>
+        <div class="w-full h-32 mb-4">
+          <app-entropy-wave></app-entropy-wave>
         </div>
+        <p class="text-sm font-semibold mb-1">{{ translations().LINES[2] }}</p>
+        <p class="text-sm opacity-90">{{ translations().LINES[3] }}</p>
       </div>
 
-      <!-- BLOQUE 3: LA SOLUCIÓN -->
-      <div class="relative group cursor-pointer transform transition-all duration-500 hover:scale-105">
-        <div class="absolute inset-0 bg-gradient-to-br from-holo-blue/20 to-transparent rounded-2xl blur-xl opacity-0 group-hover:opacity-100 transition-opacity duration-500"></div>
-        <div class="relative bg-gradient-to-br from-gray-900 to-gray-800 p-8 rounded-2xl border border-holo-blue/20 hover:border-holo-blue/50 transition-all duration-500">
-          
-          <!-- Icono animado -->
-          <div class="w-16 h-16 bg-holo-blue/20 rounded-full flex items-center justify-center mb-6 mx-auto group-hover:animate-bounce">
-            <svg class="w-8 h-8 text-holo-blue" fill="currentColor" viewBox="0 0 24 24">
-              <path d="M9 11H7v9h2v-9zm4 0h-2v9h2v-9zm4 0h-2v9h2v-9zm2-7v2H5V4h3.5l1-1h5l1 1H19z"/>
-              <path d="M12 6l-1.5 1.5L12 9l1.5-1.5L12 6z"/>
-            </svg>
-          </div>
-          
-          <h3 class="text-2xl font-heading text-holo-blue mb-4 text-center">EL MÉTODO</h3>
-          
-          <div class="space-y-3 text-gris-claro">
-            <div class="flex items-start gap-3">
-              <div class="w-2 h-2 bg-holo-blue rounded-full mt-2 flex-shrink-0"></div>
-              <p class="text-sm font-semibold">{{ translations().LINES[4] }}</p>
-            </div>
-            <div class="flex items-center gap-2 mt-4">
-              <span class="text-xs text-holo-blue font-semibold">CATALÍTICO</span>
-              <span class="text-xs text-holo-blue">•</span>
-              <span class="text-xs text-holo-blue font-semibold">QUIRÚRGICO</span>
-            </div>
-          </div>
-          
-          <!-- Métrica de transformación -->
-          <div class="mt-6 p-4 bg-black/30 rounded-lg border border-holo-blue/20">
-            <div class="text-center">
-              <div class="text-lg font-bold text-holo-blue mb-1">TRANSFORMACIÓN</div>
-              <div class="flex justify-center items-center gap-2 mt-2">
-                <div class="w-3 h-3 bg-rojo-oscuro rounded-full animate-pulse"></div>
-                <div class="w-6 h-px bg-gradient-to-r from-rojo-oscuro to-holo-blue"></div>
-                <div class="w-3 h-3 bg-holo-blue rounded-full animate-pulse"></div>
-              </div>
-            </div>
-          </div>
+      <div class="bg-gray-900 border border-holo-blue/30 rounded-2xl flex flex-col items-center p-6 text-center h-full">
+        <h3 class="text-2xl font-heading text-holo-blue mb-4">EL MÉTODO</h3>
+        <div class="w-full h-32 mb-4">
+          <app-method-transform></app-method-transform>
         </div>
+        <p class="text-sm font-semibold">{{ translations().LINES[4] }}</p>
       </div>
     </div>
 

--- a/src/app/components/between/between.ts
+++ b/src/app/components/between/between.ts
@@ -2,11 +2,14 @@ import { Component, computed } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { I18nService } from '../../core/i18n.service';
 import { Entropy } from './entropy';
+import { SymptomBar } from './symptom-bar';
+import { EntropyWave } from './entropy-wave';
+import { MethodTransform } from './method-transform';
 
 @Component({
   selector: 'app-between',
   standalone: true,
-  imports: [CommonModule, Entropy],
+  imports: [CommonModule, Entropy, SymptomBar, EntropyWave, MethodTransform],
   templateUrl: './between.html'
 })
 export class Between {

--- a/src/app/components/between/entropy-wave.html
+++ b/src/app/components/between/entropy-wave.html
@@ -1,0 +1,6 @@
+<svg viewBox="0 0 100 30" class="w-full h-full" role="img" aria-label="Entropía narrativa animada" preserveAspectRatio="none">
+  <path id="wave" d="M0 15 Q20 5 40 15 T80 15 100 15" stroke="#BFA16A" stroke-width="3" fill="none">
+    <animate attributeName="d" dur="3s" repeatCount="indefinite"
+      values="M0 15 Q20 5 40 15 T80 15 100 15; M0 15 Q20 25 40 15 T80 15 100 15; M0 15 Q20 5 40 15 T80 15 100 15" />
+  </path>
+</svg>

--- a/src/app/components/between/entropy-wave.scss
+++ b/src/app/components/between/entropy-wave.scss
@@ -1,0 +1,1 @@
+svg { width: 100%; height: 100%; }

--- a/src/app/components/between/entropy-wave.ts
+++ b/src/app/components/between/entropy-wave.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-entropy-wave',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './entropy-wave.html',
+  styleUrl: './entropy-wave.scss'
+})
+export class EntropyWave {}

--- a/src/app/components/between/method-transform.html
+++ b/src/app/components/between/method-transform.html
@@ -1,0 +1,12 @@
+<svg viewBox="0 0 100 40" class="w-full h-full" role="img" aria-label="Transformación catalítica" preserveAspectRatio="none">
+  <circle cx="20" cy="20" r="10" stroke="#264B5D" stroke-width="2" fill="none">
+    <animate attributeName="r" values="10;5;10" dur="3s" repeatCount="indefinite" />
+  </circle>
+  <line x1="35" y1="20" x2="65" y2="20" stroke="#264B5D" stroke-width="2">
+    <animate attributeName="x1" values="35;45;35" dur="3s" repeatCount="indefinite" />
+    <animate attributeName="x2" values="65;55;65" dur="3s" repeatCount="indefinite" />
+  </line>
+  <circle cx="80" cy="20" r="10" stroke="#264B5D" stroke-width="2" fill="none">
+    <animate attributeName="r" values="10;15;10" dur="3s" repeatCount="indefinite" />
+  </circle>
+</svg>

--- a/src/app/components/between/method-transform.scss
+++ b/src/app/components/between/method-transform.scss
@@ -1,0 +1,1 @@
+svg { width: 100%; height: 100%; }

--- a/src/app/components/between/method-transform.ts
+++ b/src/app/components/between/method-transform.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-method-transform',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './method-transform.html',
+  styleUrl: './method-transform.scss'
+})
+export class MethodTransform {}

--- a/src/app/components/between/symptom-bar.html
+++ b/src/app/components/between/symptom-bar.html
@@ -1,0 +1,3 @@
+<div class="symptom-bar" role="img" aria-label="Indicador de velocidad fluctuante">
+  <div class="bar" *ngFor="let b of [1,2,3,4,5]"></div>
+</div>

--- a/src/app/components/between/symptom-bar.scss
+++ b/src/app/components/between/symptom-bar.scss
@@ -1,0 +1,25 @@
+.symptom-bar {
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  height: 100%;
+  width: 100%;
+  gap: 0.25rem;
+}
+
+.bar {
+  width: 6px;
+  background-color: #7A0000;
+  animation: bar-cycle 2.5s ease-in-out infinite;
+  transform-origin: bottom;
+  height: 60%;
+}
+.bar:nth-child(2) { animation-delay: 0.2s; }
+.bar:nth-child(3) { animation-delay: 0.4s; }
+.bar:nth-child(4) { animation-delay: 0.6s; }
+.bar:nth-child(5) { animation-delay: 0.8s; }
+
+@keyframes bar-cycle {
+  0%, 100% { transform: scaleY(0.4); }
+  50% { transform: scaleY(1); }
+}

--- a/src/app/components/between/symptom-bar.ts
+++ b/src/app/components/between/symptom-bar.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-symptom-bar',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './symptom-bar.html',
+  styleUrl: './symptom-bar.scss'
+})
+export class SymptomBar {}


### PR DESCRIPTION
## Summary
- add new animated graph components for the *Between* section
- redesign cards using new components
- document the new components

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_6861f311d2d48333aa2900e0b18caf3f