### PR TITLE
Fix login i18n strings

### DIFF
--- a/src/app/core/i18n.service.ts
+++ b/src/app/core/i18n.service.ts
@@ -99,6 +99,13 @@ export const LANGUAGES = {
       EMAIL: 'Email',
       MESSAGE: 'Message',
       SEND: 'Send'
+    },
+    LOGIN: {
+      TITLE: 'Log in',
+      EMAIL: 'Email',
+      PASSWORD: 'Password',
+      SUBMIT: 'Sign In',
+      ERROR: 'Invalid credentials'
     }
   },
   es: {
@@ -199,6 +206,13 @@ export const LANGUAGES = {
       EMAIL: 'Correo',
       MESSAGE: 'Mensaje',
       SEND: 'Enviar'
+    },
+    LOGIN: {
+      TITLE: 'Iniciar sesión',
+      EMAIL: 'Correo',
+      PASSWORD: 'Contraseña',
+      SUBMIT: 'Entrar',
+      ERROR: 'Credenciales inválidas'
     }
   }
 };

--- a/src/app/features/login/login.component.html
+++ b/src/app/features/login/login.component.html
@@ -1,9 +1,9 @@
 <div class="max-w-sm mx-auto mt-12 bg-azul-noche p-6 rounded shadow text-gris-claro">
-  <h2 class="text-2xl font-heading mb-4">Iniciar sesión</h2>
+  <h2 class="text-2xl font-heading mb-4">{{ translations().TITLE }}</h2>
   <form (ngSubmit)="submit()" [formGroup]="form" class="flex flex-col gap-4">
-    <input type="email" formControlName="email" placeholder="Correo" class="p-2 bg-antracita text-gris-claro rounded">
-    <input type="password" formControlName="password" placeholder="Contraseña" class="p-2 bg-antracita text-gris-claro rounded">
-    <button type="submit" class="bg-dorado text-antracita p-2 rounded hover:bg-rojo-oscuro hover:text-gris-claro transition">Entrar</button>
+    <input type="email" formControlName="email" [placeholder]="translations().EMAIL" class="p-2 bg-antracita text-gris-claro rounded">
+    <input type="password" formControlName="password" [placeholder]="translations().PASSWORD" class="p-2 bg-antracita text-gris-claro rounded">
+    <button type="submit" class="bg-dorado text-antracita p-2 rounded hover:bg-rojo-oscuro hover:text-gris-claro transition">{{ translations().SUBMIT }}</button>
   </form>
   <p *ngIf="error" class="text-red-500 mt-2">{{ error }}</p>
 </div>

--- a/src/app/features/login/login.component.ts
+++ b/src/app/features/login/login.component.ts
@@ -1,8 +1,9 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, computed } from '@angular/core';
 import { FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
 import { AuthService } from '../../core/auth/auth.service';
 import { Router } from '@angular/router';
 import { CommonModule } from '@angular/common';
+import { I18nService } from '../../core/i18n.service';
 
 @Component({
   selector: 'app-login',
@@ -15,7 +16,9 @@ export class LoginComponent implements OnInit {
   form!: FormGroup;  // Lo declaramos sin inicializar
   error: string | null = null;
 
-  constructor(private fb: FormBuilder, private auth: AuthService, private router: Router) {}
+  readonly translations = computed(() => this.i18n.t().LOGIN);
+
+  constructor(private fb: FormBuilder, private auth: AuthService, private router: Router, private i18n: I18nService) {}
 
   ngOnInit(): void {
     this.form = this.fb.group({
@@ -30,7 +33,7 @@ export class LoginComponent implements OnInit {
     const { email, password } = this.form.value;
     this.auth.login(email!, password!).subscribe({
       next: () => this.router.navigate(['/admin']),
-      error: err => this.error = 'Credenciales inválidas'
+      error: err => this.error = this.translations().ERROR
     });
   }
 }


### PR DESCRIPTION
## Summary
- add login i18n keys for EN and ES
- use i18n in login component

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_6861f8e125748333a359d743af6088c3