### PR TITLE
Add footer translations

### DIFF
--- a/src/app/components/footer/footer.html
+++ b/src/app/components/footer/footer.html
@@ -1,11 +1,11 @@
 <footer class="bg-azul-noche text-gris-medio py-6 text-center text-sm">
   <div class="mb-2">
-    <a href="#about" class="hover:text-dorado">Sobre mí</a> |
-    <a href="#cases" class="hover:text-dorado">Casos de estudio</a> |
-    <a href="#services" class="hover:text-dorado">Servicios</a> |
-    <a href="#contact" class="hover:text-dorado">Contacto</a>
+    <a href="#about" class="hover:text-dorado">{{ translations().ABOUT }}</a> |
+    <a href="#cases" class="hover:text-dorado">{{ translations().CASES }}</a> |
+    <a href="#services" class="hover:text-dorado">{{ translations().SERVICES }}</a> |
+    <a href="#contact" class="hover:text-dorado">{{ translations().CONTACT }}</a>
   </div>
   <div class="italic text-gris-claro">
-    Trabajo para quienes buscan transformar, no para quienes buscan complacer.
+    {{ translations().MOTTO }}
   </div>
 </footer>

--- a/src/app/components/footer/footer.ts
+++ b/src/app/components/footer/footer.ts
@@ -1,4 +1,5 @@
-import { Component } from '@angular/core';
+import { Component, computed, inject } from '@angular/core';
+import { I18nService } from '../../core/i18n.service';
 
 @Component({
   selector: 'app-footer',
@@ -8,5 +9,6 @@ import { Component } from '@angular/core';
   styleUrl: './footer.scss'
 })
 export class Footer {
-
+  readonly i18n = inject(I18nService);
+  readonly translations = computed(() => this.i18n.t().FOOTER);
 }

--- a/src/app/core/i18n.service.ts
+++ b/src/app/core/i18n.service.ts
@@ -154,6 +154,13 @@ export const LANGUAGES = {
     EXPERIENCE_LIST: {
       TITLE: 'Experiences',
       SUBTITLE: 'Nothing decorative,<span class="text-dorado"> only real achievements.</span>'
+    },
+    FOOTER: {
+      ABOUT: 'About Me',
+      CASES: 'Case Studies',
+      SERVICES: 'Services',
+      CONTACT: 'Contact',
+      MOTTO: 'I work for those seeking transformation, not those seeking appeasement.'
     }
   },
   es: {
@@ -309,6 +316,13 @@ export const LANGUAGES = {
     EXPERIENCE_LIST: {
       TITLE: 'Experiencias',
       SUBTITLE: 'Nada decorativo,<span class="text-dorado"> solo logros reales.</span>'
+    },
+    FOOTER: {
+      ABOUT: 'Sobre Mí',
+      CASES: 'Casos de estudio',
+      SERVICES: 'Servicios',
+      CONTACT: 'Contacto',
+      MOTTO: 'Trabajo para quienes buscan transformar, no para quienes buscan complacer.'
     }
   }
 };


### PR DESCRIPTION
## Summary
- localize the footer component
- add footer i18n entries in English and Spanish

## Testing
- `npx ng test --watch=false` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_68621a2d3150833380ddc4ea0976bec9