### PR TITLE
Add functional contact form with toast notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,12 @@ Actualmente, el proyecto se encuentra desplegado en OnRender:
 | -------- | -------------------- | ------------------------------------- |
 | `GET`    | `/api/contacts`      | Listar todos los mensajes de contacto |
 | `POST`   | `/api/contacts`      | Enviar un mensaje de contacto         |
+
 | `DELETE` | `/api/contacts/{id}` | Eliminar un mensaje                   |
+
+El formulario de contacto de la aplicación frontend usa el endpoint `POST /api/contacts`.
+Los datos se envían mediante `HttpClient` sin recargar la página y se notifica al usuario
+con toasts cuando el envío se realiza.
 
 #### JSON ejemplo:
 

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -20,3 +20,4 @@
 <app-contact></app-contact>
 <app-footer></app-footer>
 <app-game-chat></app-game-chat>
+<app-toast-container></app-toast-container>

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -10,6 +10,7 @@ import { Contact } from './components/contact/contact';
 import { Footer } from './components/footer/footer';
 import { Banner } from './components/banner/banner';
 import { GameChatComponent } from './components/game-chat/game-chat';
+import { ToastContainerComponent } from './components/toast/toast-container';
 import { CommonModule } from '@angular/common';
 import { RouterOutlet } from '@angular/router';
 import { GameChatService } from './components/game-chat/game-chat.service';
@@ -29,6 +30,7 @@ import { Router, NavigationEnd } from '@angular/router';
     Contact,
     GameChatComponent,
     Footer,
+    ToastContainerComponent,
     CommonModule,
     RouterOutlet
   ],

--- a/src/app/components/contact/contact.html
+++ b/src/app/components/contact/contact.html
@@ -5,12 +5,15 @@
       <span class="text-dorado">{{ translations().TITLE_LINE_2 }}</span>
     </h2>
     <p class="text-sm mb-4 italic">{{ translations().SUBTEXT }}</p>
-    <form class="flex flex-col gap-4">
-      <input type="text" [placeholder]="translations().NAME" class="bg-azul-noche border border-antracita p-2 text-gris-claro focus:outline-none focus:border-dorado">
-      <input type="email" [placeholder]="translations().EMAIL" class="bg-azul-noche border border-antracita p-2 text-gris-claro focus:outline-none focus:border-dorado">
-      <textarea [placeholder]="translations().MESSAGE" class="bg-azul-noche border border-antracita p-2 text-gris-claro focus:outline-none focus:border-dorado"></textarea>
+    <form class="flex flex-col gap-4" [formGroup]="form" (ngSubmit)="submit()">
+      <input type="text" formControlName="name" [placeholder]="translations().NAME" (input)="hint('name')"
+        class="bg-azul-noche border border-antracita p-2 text-gris-claro focus:outline-none focus:border-dorado">
+      <input type="email" formControlName="email" [placeholder]="translations().EMAIL" (input)="hint('email')"
+        class="bg-azul-noche border border-antracita p-2 text-gris-claro focus:outline-none focus:border-dorado">
+      <textarea formControlName="message" [placeholder]="translations().MESSAGE" (input)="hint('message')"
+        class="bg-azul-noche border border-antracita p-2 text-gris-claro focus:outline-none focus:border-dorado"></textarea>
       <button type="submit" class="border border-dorado text-gris-claro px-4 py-2 hover:bg-rojo-oscuro/70 hover:shadow-lg transition-colors">
-        {{ translations().BUTTON }}
+        {{ translations().SEND }}
       </button>
     </form>
   </div>

--- a/src/app/components/contact/contact.service.ts
+++ b/src/app/components/contact/contact.service.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../../environments/environment';
+
+export interface ContactPayload {
+  name: string;
+  email: string;
+  message: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class ContactService {
+  private url = `${environment.apiRoot}/contacts`;
+
+  constructor(private http: HttpClient) {}
+
+  sendContact(payload: ContactPayload): Observable<any> {
+    return this.http.post(this.url, payload);
+  }
+}

--- a/src/app/components/contact/contact.ts
+++ b/src/app/components/contact/contact.ts
@@ -1,15 +1,52 @@
 import { Component, computed } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { I18nService } from '../../core/i18n.service';
+import { ContactService } from './contact.service';
+import { ToastService } from '../toast/toast.service';
 
 @Component({
   selector: 'app-contact',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, ReactiveFormsModule],
   templateUrl: './contact.html',
   styleUrl: './contact.scss'
 })
 export class Contact {
   readonly translations = computed(() => this.i18n.t().CTA);
-  constructor(private i18n: I18nService) {}
+  readonly form = this.fb.group({
+    name: ['', Validators.required],
+    email: ['', [Validators.required, Validators.email]],
+    message: ['', Validators.required]
+  });
+
+  constructor(
+    private fb: FormBuilder,
+    private i18n: I18nService,
+    private service: ContactService,
+    private toast: ToastService
+  ) {}
+
+  hint(field: 'name' | 'email' | 'message') {
+    const map = {
+      name: this.translations().NAME,
+      email: this.translations().EMAIL,
+      message: this.translations().MESSAGE
+    } as const;
+    this.toast.show(map[field]);
+  }
+
+  submit() {
+    if (this.form.invalid) {
+      this.toast.show('Formulario inválido');
+      return;
+    }
+    this.service.sendContact(this.form.value).subscribe({
+      next: () => {
+        this.toast.show('Correo enviado con éxito.');
+        this.form.reset();
+      },
+      error: () => this.toast.show('Error al enviar correo')
+    });
+  }
 }

--- a/src/app/components/toast/toast-container.ts
+++ b/src/app/components/toast/toast-container.ts
@@ -1,0 +1,19 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ToastService } from './toast.service';
+
+@Component({
+  selector: 'app-toast-container',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <div class="fixed bottom-4 right-4 space-y-2 z-50">
+      <div *ngFor="let toast of toastService.toasts()" class="bg-dorado text-antracita px-4 py-2 rounded shadow">
+        {{ toast.text }}
+      </div>
+    </div>
+  `
+})
+export class ToastContainerComponent {
+  constructor(public toastService: ToastService) {}
+}

--- a/src/app/components/toast/toast.service.ts
+++ b/src/app/components/toast/toast.service.ts
@@ -1,0 +1,20 @@
+import { Injectable, signal } from '@angular/core';
+
+export interface ToastMessage {
+  id: number;
+  text: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class ToastService {
+  private counter = 0;
+  readonly toasts = signal<ToastMessage[]>([]);
+
+  show(text: string, duration = 3000) {
+    const toast = { id: this.counter++, text };
+    this.toasts.update(list => [...list, toast]);
+    setTimeout(() => {
+      this.toasts.update(list => list.filter(t => t.id !== toast.id));
+    }, duration);
+  }
+}


### PR DESCRIPTION
## Summary
- create Toast service and container component
- create Contact service to call `/api/contacts`
- make contact component reactive and show field hints with toasts
- show confirmation toast on submit
- mount toast container at app root
- update README with API reference for the contact form

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_686225ea81ec8333a241b2a47ed82ef2